### PR TITLE
Make the party edit screen show party members properly

### DIFF
--- a/screens/PartyEditScreen.tscn
+++ b/screens/PartyEditScreen.tscn
@@ -59,7 +59,6 @@ layout_mode = 2
 theme_override_fonts/font = ExtResource("1_isnm2")
 theme_override_font_sizes/font_size = 25
 max_text_lines = 10
-fixed_column_width = 1
 
 [node name="GridContainer" type="HBoxContainer" parent="CenterContainer/Reserves"]
 texture_filter = 2


### PR DESCRIPTION
For whatever reason the new godot version makes the names of reserve party members invisible unless you do this.